### PR TITLE
Drop new suffix from domain names

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -9,7 +9,7 @@ new Cerebro(app, {
     stack: "media-service", 
     stage: "TEST", 
     instanceSize: InstanceSize.SMALL,
-    domainName: "cerebro-new.media.test.dev-gutools.co.uk",
+    domainName: "cerebro.media.test.dev-gutools.co.uk",
     cerebroVersion: "0.9.4",
 });
 
@@ -17,6 +17,6 @@ new Cerebro(app, {
     stack: "media-service", 
     stage: "PROD", 
     instanceSize: InstanceSize.SMALL,
-    domainName: "cerebro-new.media.gutools.co.uk",
+    domainName: "cerebro.media.gutools.co.uk",
     cerebroVersion: "0.9.4",
 });


### PR DESCRIPTION
## What does this change?
DNS changes since we are decommissioning the old service:

`cerebro-new.media.gutools.co.uk` -> `cerebro.media.gutools.co.uk`
`cerebro-new.media.test.dev-gutools.co.uk` -> `cerebro.media.test.dev-gutools.co.uk`

Will need to use the riff-raff dangerous deploy strategy since it deletes a CNAME and an ACM certificate