### PR TITLE
reflect change to ES stack

### DIFF
--- a/cdk/lib/__snapshots__/cerebro.test.ts.snap
+++ b/cdk/lib/__snapshots__/cerebro.test.ts.snap
@@ -81,7 +81,7 @@ exports[`The Cerebro stack matches the snapshot 1`] = `
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "elasticsearchUrl": {
-      "Default": "/TEST/grid-elasticsearch/elasticsearch/url",
+      "Default": "/TEST/media-service/elasticsearch/url",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },

--- a/cdk/lib/cerebro.ts
+++ b/cdk/lib/cerebro.ts
@@ -25,7 +25,7 @@ export class Cerebro extends GuStack {
 
     const esUrl = new GuStringParameter(this, 'elasticsearchUrl', {
       fromSSM: true,
-      default: `/${props.stage}/grid-elasticsearch/elasticsearch/url`,
+      default: `/${props.stage}/media-service/elasticsearch/url`,
     });
 
     const cerebroApp = new GuEc2App(this, {


### PR DESCRIPTION
https://github.com/guardian/editorial-tools-platform/pull/689 changes the `Stack` name for ElasticSearch instances, this PR reflects that change (similar to https://github.com/guardian/grid/pull/4089).