### PR TITLE
Avoid hardcoded string

### DIFF
--- a/cdk/lib/cerebro.ts
+++ b/cdk/lib/cerebro.ts
@@ -25,7 +25,7 @@ export class Cerebro extends GuStack {
 
     const esUrl = new GuStringParameter(this, 'elasticsearchUrl', {
       fromSSM: true,
-      default: `/${props.stage}/media-service/elasticsearch/url`,
+      default: `/${props.stage}/${props.stack}/elasticsearch/url`,
     });
 
     const cerebroApp = new GuEc2App(this, {


### PR DESCRIPTION
## What does this change?

Grid's elasticsearch stack was `grid-elasticsearch`, but the other Grid microservices stack is `media-service`.

We've now made this consistent, so we can use `${props.stack}` in `cerbro.ts` which might make it easier for other teams to user grid-cerebro for their own clusters.

Resolves [issue 1](https://github.com/guardian/grid-cerebro/issues/1) 